### PR TITLE
fix: localeToCharset가 여러 값을 반환할 때 인코딩 검사 오류 수정

### DIFF
--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -109,12 +109,15 @@
   assign("backupUserDic", file.path(backupUserDicPath,DicUser), .KoNLPEnv)
   assign("ScalaVer", .ScalaVer, .KoNLPEnv)
 
-  if(is.na(localeToCharset()) != TRUE) {
-    if(all((localeToCharset()[1] == c("UTF-8", "CP949", "EUC-KR")) == FALSE)){
-      packageStartupMessage("This R shell doesn't contain any Hangul encoding.\nFor fully use, any of 'UTF-8', 'CP949', 'EUC-KR' needs to be used for R shell encoding.")
-    }
-  } else {
-    packageStartupMessage("This R shell doesn't contain any Hangul encoding.\nFor fully use, any of 'UTF-8', 'CP949', 'EUC-KR' needs to be used for R shell encoding.")
+  # 로케일의 모든 인코딩을 확인합니다.
+  charsets <- localeToCharset()
+  
+  # 한국어 인코딩 리스트
+  valid_encodings <- c("UTF-8", "CP949", "EUC-KR")
+  
+  # 하나라도 유효한 한국어 인코딩이 포함되지 않은 경우 메시지 출력
+  if (!any(charsets %in% valid_encodings)) {
+    packageStartupMessage("This R shell doesn't contain any Hangul encoding.\nFor full functionality, please use one of 'UTF-8', 'CP949', or 'EUC-KR' for R shell encoding.")
   }
 }
 


### PR DESCRIPTION
### 설명

`localeToCharset()` 함수가 두 개 이상의 인코딩 정보를 반환하는 경우에도 정확하게 한글 인코딩 여부를 판단할 수 있도록 로직을 수정하였습니다.  
기존 코드에서는 첫 번째 값만 비교하였기 때문에 실제로는 유효한 인코딩이 포함되어 있어도 잘못된 경고 메시지가 출력되며 로드가 불가능한 문제가 있었습니다.  
이 문제는 리눅스에서 개발 환경을 구축하려고 시도할 때 발생했습니다. 이처럼 OS별 반환값이 다를 수 있으므로 다중 인코딩 대응이 필수적입니다.

#### 예시

예를 들어 `localeToCharset()`이 아래와 같은 결과를 반환하는 경우:

```R
charsets <- c("US-ASCII", "UTF-8")
```

기존 코드:
```R
if (all((localeToCharset()[1] == c("UTF-8", "CP949", "EUC-KR")) == FALSE)) {
```

- 첫 번째 값 `"US-ASCII"`만 검사 → 경고 메시지 출력됨 (오류)

개선된 코드:
```R
# 로케일의 모든 인코딩을 확인합니다.
charsets <- localeToCharset()

# 한국어 인코딩 리스트
valid_encodings <- c("UTF-8", "CP949", "EUC-KR")

# 하나라도 유효한 한국어 인코딩이 포함되지 않은 경우 메시지 출력
if (!any(charsets %in% valid_encodings)) {
```
- 모든 인코딩 값을 검사하도록 개선 → `"UTF-8"`이 포함되어 있으므로 경고 없이 통과 (정상)